### PR TITLE
corresponds to chatwork version 2

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 )
 
-const BaseUrl = `https://api.chatwork.com/v1`
+const BaseUrl = `https://api.chatwork.com/v2`
 
 type Me struct {
 	AccountId        int    `json:"account_id"`
@@ -175,7 +175,7 @@ type Account struct {
 }
 
 type Message struct {
-	MessageId  int     `json:"message_id"`
+	MessageId  string  `json:"message_id"`
 	Account    Account `json:"account"`
 	Body       string  `json:"body"`
 	SendTime   int64   `json:"send_time"`
@@ -204,7 +204,7 @@ type Task struct {
 	TaskId            int     `json:"task_id"`
 	Account           Account `json:"account"`
 	AssignedByAccount Account `json:"assigned_by_account"`
-	MessageId         int     `json:"message_id"`
+	MessageId         string  `json:"message_id"`
 	Body              string  `json:"body"`
 	LimitTime         int64   `json:"limit_time"`
 	Status            string  `json:"status"`
@@ -235,7 +235,7 @@ func (c *Client) RoomTask(roomId, taskId string) Task {
 type File struct {
 	FileId     int     `json:"file_id"`
 	Account    Account `json:"account"`
-	MessageId  int     `json:"message_id"`
+	MessageId  string  `json:"message_id"`
 	Filename   string  `json:"filename"`
 	Filesize   int     `json:"filesize"`
 	UploadTime int64   `json:"upload_time"`


### PR DESCRIPTION
Correction according to api specification amendment.
https://goo.gl/hh6Igd

- change base url v1 to v2.
- change type of message_id Int to String.

Support for v1 is over, so we do not need to consider it.